### PR TITLE
update the /proverOpt parameter to fix compilation error

### DIFF
--- a/AbstractPlatform/Makefile
+++ b/AbstractPlatform/Makefile
@@ -5,7 +5,7 @@ else
 	BOOGIESMOKE:=
 endif
 
-BOOGIEOPT:=/z3opt:smt.RELEVANCY=0 /z3opt:smt.CASE_SPLIT=0 /errorLimit:1 $(BOOGIESMOKE)
+BOOGIEOPT:=/proverOpt:O:smt.relevancy=0 /proverOpt:O:smt.case_split=0 /errorLimit:1 $(BOOGIESMOKE) 
 
 COMMON=../Common
 BUILD=build

--- a/Common/Makefile
+++ b/Common/Makefile
@@ -1,4 +1,4 @@
-BOOGIEOPT:=/z3opt:smt.RELEVANCY=0 /z3opt:smt.CASE_SPLIT=0 /errorLimit:1
+BOOGIEOPT:=/proverOpt:O:smt.relevancy=0 /proverOpt:O:smt.case_split=0 /errorLimit:1
 
 BUILD=build
 CACHE_TARGET:=$(BUILD)/Cache.xml

--- a/SGX/Makefile
+++ b/SGX/Makefile
@@ -1,4 +1,4 @@
-BOOGIEOPT:=/z3opt:smt.RELEVANCY=0 /z3opt:smt.CASE_SPLIT=0 /errorLimit:1
+BOOGIEOPT:=/proverOpt:O:smt.relevancy=0 /proverOpt:O:smt.case_split=0 /errorLimit:1
 BUILD=build
 
 SGX_PROOF_TARGET=$(BUILD)/SGXProof.xml

--- a/Sanctum/Makefile
+++ b/Sanctum/Makefile
@@ -1,4 +1,4 @@
-BOOGIEOPT:=/z3opt:smt.RELEVANCY=0 /z3opt:smt.CASE_SPLIT=0 /errorLimit:1
+BOOGIEOPT:=/proverOpt:O:smt.relevancy=0 /proverOpt:O:smt.case_split=0 /errorLimit:1
 MMU:=MMU
 CPU:=CPU
 HOST:=Host


### PR DESCRIPTION
For the boogie with version > `2.5.0`, the Makefile will have compilation error that failed to recognize parametr `/z3opt`. The current 2 issues also reported this error.
I update all Makefiles in this branch.